### PR TITLE
docs: update README with project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,57 @@
-# Astro Starter Kit: Minimal
+# John's Glazenwassersbedrijf
 
-```sh
-npm create astro@latest -- --template minimal
+Website for John's Glazenwassersbedrijf, a professional window cleaning company based in the Betuwe region of the Netherlands.
+
+## Tech Stack
+
+- [Astro](https://astro.build) - Static site generator
+- [Tailwind CSS v4](https://tailwindcss.com) - Utility-first CSS framework
+- [Lucide Icons](https://lucide.dev) - Icon library
+
+## Project Structure
+
 ```
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
 /
 ├── public/
+│   └── robots.txt
 ├── src/
-│   └── pages/
-│       └── index.astro
+│   ├── assets/
+│   │   └── images/         # Optimized images (auto-converted to WebP)
+│   ├── components/
+│   │   ├── common/         # Header, Footer
+│   │   └── home/           # Hero, ServiceCards, Reviews, TrustBar
+│   ├── layouts/
+│   │   └── Layout.astro    # Base layout
+│   ├── lib/                # Utilities
+│   ├── pages/
+│   │   ├── diensten/       # Service pages
+│   │   ├── index.astro     # Homepage
+│   │   ├── over-ons.astro  # About page
+│   │   ├── contact.astro   # Contact page
+│   │   └── offerte.astro   # Quote calculator
+│   └── styles/
+│       └── global.css      # Global styles
+├── astro.config.mjs
+├── tailwind.config.js
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Commands
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+| Command           | Action                                       |
+| :---------------- | :------------------------------------------- |
+| `npm install`     | Install dependencies                         |
+| `npm run dev`     | Start dev server at `localhost:4321`         |
+| `npm run build`   | Build production site to `./dist/`           |
+| `npm run preview` | Preview production build locally             |
 
-Any static assets, like images, can be placed in the `public/` directory.
+## Services
 
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+- Glasbewassing (Window cleaning)
+- Zonnepanelen reinigen (Solar panel cleaning)
+- Dakgoten leegmaken (Gutter cleaning)
+- Houtwerk & Trespa (Woodwork & Trespa cleaning)
+- Bouwoplevering (Construction handover cleaning)
+- Kantoor reiniging (Office cleaning)
+- Dakpannen reinigen (Roof tile cleaning)
+- Telewash systeem (High-reach cleaning)


### PR DESCRIPTION
## Summary
- Replace default Astro starter README with project-specific documentation
- Add tech stack, project structure, and services list

Closes #3