### PR TITLE
fix: remove deprecated hybrid output option

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,6 @@ import cloudflare from '@astrojs/cloudflare';
 
 // https://astro.build/config
 export default defineConfig({
-    output: 'hybrid',
     adapter: cloudflare(),
     vite: {
         plugins: [tailwind()],


### PR DESCRIPTION
## Summary
- Remove `output: 'hybrid'` from astro.config.mjs
- Astro 5 removed this option; static mode now has the same behavior

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)