### PR TITLE
Add location pages with Google Maps for 5 cities

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -6,7 +6,7 @@ const currentYear = new Date().getFullYear();
 <footer class="bg-navy text-white pt-16 pb-8">
     <div class="container mx-auto px-4">
         <div
-            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12"
+            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12 mb-12"
         >
             <!-- Brand -->
             <div>
@@ -124,6 +124,50 @@ const currentYear = new Date().getFullYear();
                             href="/diensten/telewash"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Telewash Systeem</a
+                        >
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Locaties -->
+            <div>
+                <h3 class="font-heading font-bold text-lg mb-4 text-accent">
+                    Locaties
+                </h3>
+                <ul class="space-y-3">
+                    <li>
+                        <a
+                            href="/glazenwasser-tiel"
+                            class="text-gray-300 hover:text-white transition-colors"
+                            >Glazenwasser Tiel</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="/glazenwasser-geldermalsen"
+                            class="text-gray-300 hover:text-white transition-colors"
+                            >Glazenwasser Geldermalsen</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="/glazenwasser-culemborg"
+                            class="text-gray-300 hover:text-white transition-colors"
+                            >Glazenwasser Culemborg</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="/glazenwasser-meteren"
+                            class="text-gray-300 hover:text-white transition-colors"
+                            >Glazenwasser Meteren</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="/glazenwasser-buren"
+                            class="text-gray-300 hover:text-white transition-colors"
+                            >Glazenwasser Buren</a
                         >
                     </li>
                 </ul>

--- a/src/pages/glazenwasser-buren.astro
+++ b/src/pages/glazenwasser-buren.astro
@@ -1,0 +1,104 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/common/Header.astro";
+import Footer from "../components/common/Footer.astro";
+---
+
+<Layout title="Glazenwasser Buren" description="Professionele glazenwasser in Buren. John's Glazenwassersbedrijf zorgt voor streeploos schone ramen bij particulieren en bedrijven.">
+    <Header />
+    <main>
+        <section class="bg-primary text-white pt-32 pb-20 text-center">
+            <div class="container mx-auto px-4">
+                <span class="text-accent font-bold tracking-wide uppercase text-sm mb-2 block">
+                    Uw lokale glazenwasser
+                </span>
+                <h1 class="font-heading font-extrabold text-5xl mb-4">
+                    Glazenwasser Buren
+                </h1>
+                <p class="text-xl max-w-2xl mx-auto opacity-90">
+                    Bent u op zoek naar een geschikte glazenwasser in Buren? Dan bent u bij John's Glazenwassersbedrijf aan het juiste adres. Al sinds 2007 verzorgen wij de glasbewassing in de Betuwe.
+                </p>
+                <div class="mt-8">
+                    <a
+                        href="/offerte"
+                        class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
+                    >
+                        Vraag een offerte aan
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20 bg-white">
+            <div class="container mx-auto px-4 max-w-4xl">
+                <h2 class="font-heading font-bold text-3xl text-navy mb-6">
+                    Uw glazenwasser in Buren en omgeving
+                </h2>
+                <p class="text-lg text-gray-600 mb-8">
+                    Al sinds 2007 verzorgen wij de glasbewassing in de Betuwe en omstreken, waaronder Buren.
+                    Naast het wassen van uw ramen reinigen wij ook uw kozijnen. Op verzoek kunnen wij ook uw
+                    kunststof schroten of rolluiken meenemen.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Flexibel in afspraken</h3>
+                <p class="text-lg text-gray-600 mb-8">
+                    Moet u bij de afspraak aanwezig zijn? Dat hoeft niet! Alles wordt vooraf besproken en afgestemd.
+                    Of u nu thuis wilt zijn of liever de poort open laat - wij passen ons aan.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Onze diensten in Buren</h3>
+                <ul class="space-y-4 mb-8">
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Ramen wassen binnen en buiten</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kozijnen reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kunststof schroten reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Rolluiken schoonmaken</span>
+                    </li>
+                </ul>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Werkgebied</h3>
+                <div class="rounded-2xl overflow-hidden shadow-xl mb-12">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d39266.69847877894!2d5.3372!3d51.9117!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c63f0f5a3b3b3b%3A0x4c8b3b3b3b3b3b3b!2sBuren!5e0!3m2!1snl!2snl!4v1234567890"
+                        width="100%"
+                        height="400"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Kaart van Buren"
+                    ></iframe>
+                </div>
+
+            </div>
+        </section>
+
+        <section class="bg-primary text-white py-20 text-center">
+            <div class="container mx-auto px-4">
+                <h2 class="font-heading font-extrabold text-4xl mb-6">
+                    Klaar voor een frisse blik?
+                </h2>
+                <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                    Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
+                </p>
+                <a
+                    href="/offerte"
+                    class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </section>
+    </main>
+    <Footer />
+</Layout>

--- a/src/pages/glazenwasser-culemborg.astro
+++ b/src/pages/glazenwasser-culemborg.astro
@@ -1,0 +1,104 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/common/Header.astro";
+import Footer from "../components/common/Footer.astro";
+---
+
+<Layout title="Glazenwasser Culemborg" description="Professionele glazenwasser in Culemborg. John's Glazenwassersbedrijf zorgt voor streeploos schone ramen bij particulieren en bedrijven.">
+    <Header />
+    <main>
+        <section class="bg-primary text-white pt-32 pb-20 text-center">
+            <div class="container mx-auto px-4">
+                <span class="text-accent font-bold tracking-wide uppercase text-sm mb-2 block">
+                    Uw lokale glazenwasser
+                </span>
+                <h1 class="font-heading font-extrabold text-5xl mb-4">
+                    Glazenwasser Culemborg
+                </h1>
+                <p class="text-xl max-w-2xl mx-auto opacity-90">
+                    Bent u op zoek naar een geschikte glazenwasser in Culemborg? Dan bent u bij John's Glazenwassersbedrijf aan het juiste adres. Al sinds 2007 verzorgen wij de glasbewassing in de Betuwe.
+                </p>
+                <div class="mt-8">
+                    <a
+                        href="/offerte"
+                        class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
+                    >
+                        Vraag een offerte aan
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20 bg-white">
+            <div class="container mx-auto px-4 max-w-4xl">
+                <h2 class="font-heading font-bold text-3xl text-navy mb-6">
+                    Uw glazenwasser in Culemborg en omgeving
+                </h2>
+                <p class="text-lg text-gray-600 mb-8">
+                    Al sinds 2007 verzorgen wij de glasbewassing in de Betuwe en omstreken, waaronder Culemborg.
+                    Naast het wassen van uw ramen reinigen wij ook uw kozijnen. Op verzoek kunnen wij ook uw
+                    kunststof schroten of rolluiken meenemen.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Flexibel in afspraken</h3>
+                <p class="text-lg text-gray-600 mb-8">
+                    Moet u bij de afspraak aanwezig zijn? Dat hoeft niet! Sommige klanten zijn graag thuis,
+                    anderen laten de poort open. Alles is mogelijk - we bespreken dit vooraf met u.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Onze diensten in Culemborg</h3>
+                <ul class="space-y-4 mb-8">
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Ramen wassen binnen en buiten</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kozijnen reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kunststof schroten reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Rolluiken schoonmaken</span>
+                    </li>
+                </ul>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Werkgebied</h3>
+                <div class="rounded-2xl overflow-hidden shadow-xl mb-12">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d39266.69847877894!2d5.2278!3d51.9553!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c63f0f5a3b3b3b%3A0x4c8b3b3b3b3b3b3b!2sCulemborg!5e0!3m2!1snl!2snl!4v1234567890"
+                        width="100%"
+                        height="400"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Kaart van Culemborg"
+                    ></iframe>
+                </div>
+
+            </div>
+        </section>
+
+        <section class="bg-primary text-white py-20 text-center">
+            <div class="container mx-auto px-4">
+                <h2 class="font-heading font-extrabold text-4xl mb-6">
+                    Klaar voor een frisse blik?
+                </h2>
+                <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                    Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
+                </p>
+                <a
+                    href="/offerte"
+                    class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </section>
+    </main>
+    <Footer />
+</Layout>

--- a/src/pages/glazenwasser-geldermalsen.astro
+++ b/src/pages/glazenwasser-geldermalsen.astro
@@ -1,0 +1,98 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/common/Header.astro";
+import Footer from "../components/common/Footer.astro";
+---
+
+<Layout title="Glazenwasser Geldermalsen" description="Professionele glazenwasser in Geldermalsen. John's Glazenwassersbedrijf zorgt voor streeploos schone ramen bij particulieren en bedrijven.">
+    <Header />
+    <main>
+        <section class="bg-primary text-white pt-32 pb-20 text-center">
+            <div class="container mx-auto px-4">
+                <span class="text-accent font-bold tracking-wide uppercase text-sm mb-2 block">
+                    Uw lokale glazenwasser
+                </span>
+                <h1 class="font-heading font-extrabold text-5xl mb-4">
+                    Glazenwasser Geldermalsen
+                </h1>
+                <p class="text-xl max-w-2xl mx-auto opacity-90">
+                    In Geldermalsen hebben wij een groot aantal particulieren en bedrijven als klant. Voor zowel glasbewassing binnen en buiten, als voor de totale schoonmaak kunt u bij ons terecht!
+                </p>
+                <div class="mt-8">
+                    <a
+                        href="/offerte"
+                        class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
+                    >
+                        Vraag een offerte aan
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20 bg-white">
+            <div class="container mx-auto px-4 max-w-4xl">
+                <h2 class="font-heading font-bold text-3xl text-navy mb-6">
+                    Uw glazenwasser in Geldermalsen en omgeving
+                </h2>
+                <p class="text-lg text-gray-600 mb-8">
+                    In Geldermalsen hebben wij een groot aantal particulieren en bedrijven als klant. Voor zowel
+                    glasbewassing binnen en buiten kunt u bij ons terecht. Wij zorgen ervoor dat uw ramen er
+                    weer stralend uitzien.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Onze diensten in Geldermalsen</h3>
+                <ul class="space-y-4 mb-8">
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Glasbewassing binnen en buiten</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Glasbewassing voor particulieren</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Glasbewassing voor bedrijven</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kozijnen reinigen</span>
+                    </li>
+                </ul>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Werkgebied</h3>
+                <div class="rounded-2xl overflow-hidden shadow-xl mb-12">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d39266.69847877894!2d5.2911!3d51.8820!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c63f0f5a3b3b3b%3A0x4c8b3b3b3b3b3b3b!2sGeldermalsen!5e0!3m2!1snl!2snl!4v1234567890"
+                        width="100%"
+                        height="400"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Kaart van Geldermalsen"
+                    ></iframe>
+                </div>
+
+            </div>
+        </section>
+
+        <section class="bg-primary text-white py-20 text-center">
+            <div class="container mx-auto px-4">
+                <h2 class="font-heading font-extrabold text-4xl mb-6">
+                    Klaar voor een frisse blik?
+                </h2>
+                <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                    Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
+                </p>
+                <a
+                    href="/offerte"
+                    class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </section>
+    </main>
+    <Footer />
+</Layout>

--- a/src/pages/glazenwasser-meteren.astro
+++ b/src/pages/glazenwasser-meteren.astro
@@ -1,0 +1,98 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/common/Header.astro";
+import Footer from "../components/common/Footer.astro";
+---
+
+<Layout title="Glazenwasser Meteren" description="Professionele glazenwasser in Meteren. John's Glazenwassersbedrijf zorgt voor streeploos schone ramen bij particulieren en bedrijven.">
+    <Header />
+    <main>
+        <section class="bg-primary text-white pt-32 pb-20 text-center">
+            <div class="container mx-auto px-4">
+                <span class="text-accent font-bold tracking-wide uppercase text-sm mb-2 block">
+                    Uw lokale glazenwasser
+                </span>
+                <h1 class="font-heading font-extrabold text-5xl mb-4">
+                    Glazenwasser Meteren
+                </h1>
+                <p class="text-xl max-w-2xl mx-auto opacity-90">
+                    In Meteren hebben wij zowel bedrijfspanden als particuliere woonhuizen te onderhouden. Van "oud" Meteren tot Kalenberg en Plantage - wij kennen de buurt!
+                </p>
+                <div class="mt-8">
+                    <a
+                        href="/offerte"
+                        class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
+                    >
+                        Vraag een offerte aan
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20 bg-white">
+            <div class="container mx-auto px-4 max-w-4xl">
+                <h2 class="font-heading font-bold text-3xl text-navy mb-6">
+                    Uw glazenwasser in Meteren en omgeving
+                </h2>
+                <p class="text-lg text-gray-600 mb-8">
+                    In Meteren hebben wij zowel bedrijfspanden als particuliere woonhuizen te onderhouden.
+                    Of u nu in "oud" Meteren woont, in de Kalenberg of in Plantage - wij komen graag bij u langs
+                    voor het onderhoud van uw ramen en kozijnen.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Onze diensten in Meteren</h3>
+                <ul class="space-y-4 mb-8">
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Ramen en kozijnen voor particulieren</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Bedrijfspanden onderhouden</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>VVE trappenhuizen en gemeenschappelijke ruimtes</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kozijnen reinigen</span>
+                    </li>
+                </ul>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Werkgebied</h3>
+                <div class="rounded-2xl overflow-hidden shadow-xl mb-12">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d39266.69847877894!2d5.2833!3d51.8631!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c63f0f5a3b3b3b%3A0x4c8b3b3b3b3b3b3b!2sMeteren!5e0!3m2!1snl!2snl!4v1234567890"
+                        width="100%"
+                        height="400"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Kaart van Meteren"
+                    ></iframe>
+                </div>
+
+            </div>
+        </section>
+
+        <section class="bg-primary text-white py-20 text-center">
+            <div class="container mx-auto px-4">
+                <h2 class="font-heading font-extrabold text-4xl mb-6">
+                    Klaar voor een frisse blik?
+                </h2>
+                <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                    Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
+                </p>
+                <a
+                    href="/offerte"
+                    class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </section>
+    </main>
+    <Footer />
+</Layout>

--- a/src/pages/glazenwasser-tiel.astro
+++ b/src/pages/glazenwasser-tiel.astro
@@ -1,0 +1,108 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/common/Header.astro";
+import Footer from "../components/common/Footer.astro";
+---
+
+<Layout title="Glazenwasser Tiel" description="Professionele glazenwasser in Tiel. John's Glazenwassersbedrijf zorgt voor streeploos schone ramen bij particulieren en bedrijven.">
+    <Header />
+    <main>
+        <section class="bg-primary text-white pt-32 pb-20 text-center">
+            <div class="container mx-auto px-4">
+                <span class="text-accent font-bold tracking-wide uppercase text-sm mb-2 block">
+                    Uw lokale glazenwasser
+                </span>
+                <h1 class="font-heading font-extrabold text-5xl mb-4">
+                    Glazenwasser Tiel
+                </h1>
+                <p class="text-xl max-w-2xl mx-auto opacity-90">
+                    Al sinds 2007 verzorgen wij de glasbewassing in Tiel en de rest van de Betuwe. Naast het wassen van uw ramen reinigen wij ook uw kozijnen en desgewenst kunststof schroten of rolluiken.
+                </p>
+                <div class="mt-8">
+                    <a
+                        href="/offerte"
+                        class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
+                    >
+                        Vraag een offerte aan
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-20 bg-white">
+            <div class="container mx-auto px-4 max-w-4xl">
+                <h2 class="font-heading font-bold text-3xl text-navy mb-6">
+                    Uw glazenwasser in Tiel en omgeving
+                </h2>
+                <p class="text-lg text-gray-600 mb-4">
+                    Bent u op zoek naar een geschikte glazenwasser in Tiel? Dan bent u bij John's Glazenwassersbedrijf
+                    aan het juiste adres. Al sinds 2007 verzorgen wij de glasbewassing in de Betuwe en omstreken.
+                </p>
+                <p class="text-lg text-gray-600 mb-8">
+                    Naast het wassen van uw ramen reinigen wij ook uw kozijnen. Op verzoek kunnen wij ook uw
+                    kunststof schroten of rolluiken meenemen in de schoonmaakbeurt.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Flexibel in afspraken</h3>
+                <p class="text-lg text-gray-600 mb-8">
+                    Sommige mensen willen graag aanwezig zijn tijdens het ramen lappen, terwijl anderen liever de
+                    poort open laten op de dag dat we komen. Beide opties zijn mogelijk - we stemmen dit vooraf
+                    met u af.
+                </p>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Onze diensten in Tiel</h3>
+                <ul class="space-y-4 mb-8">
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Ramen wassen binnen en buiten</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kozijnen reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Kunststof schroten reinigen</span>
+                    </li>
+                    <li class="flex items-center gap-3 text-lg text-gray-600">
+                        <span class="text-green-500 text-xl">✓</span>
+                        <span>Rolluiken schoonmaken</span>
+                    </li>
+                </ul>
+
+                <h3 class="font-heading font-bold text-2xl text-navy mt-12 mb-4">Werkgebied</h3>
+                <div class="rounded-2xl overflow-hidden shadow-xl mb-12">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d39266.69847877894!2d5.3997!3d51.8867!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c63f0f5a3b3b3b%3A0x4c8b3b3b3b3b3b3b!2sTiel!5e0!3m2!1snl!2snl!4v1234567890"
+                        width="100%"
+                        height="400"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Kaart van Tiel"
+                    ></iframe>
+                </div>
+
+            </div>
+        </section>
+
+        <section class="bg-primary text-white py-20 text-center">
+            <div class="container mx-auto px-4">
+                <h2 class="font-heading font-extrabold text-4xl mb-6">
+                    Klaar voor een frisse blik?
+                </h2>
+                <p class="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+                    Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
+                </p>
+                <a
+                    href="/offerte"
+                    class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </section>
+    </main>
+    <Footer />
+</Layout>


### PR DESCRIPTION
## Summary
- Add location-specific landing pages for Tiel, Geldermalsen, Culemborg, Meteren, and Buren
- Each page includes city-specific copy, services list, embedded Google Maps, and CTA
- Add Locaties section to footer with links to all location pages

## Pages created
- `/glazenwasser-tiel/`
- `/glazenwasser-geldermalsen/`
- `/glazenwasser-culemborg/`
- `/glazenwasser-meteren/`
- `/glazenwasser-buren/`

## Test plan
- [ ] Verify all 5 location pages load correctly
- [ ] Check Google Maps embeds display properly
- [ ] Verify footer Locaties links work
- [ ] Test responsive layout on mobile

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)