### PR TITLE
fix: improve mobile UX for header, hero, and trust elements

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -180,11 +180,8 @@ const currentYear = new Date().getFullYear();
                 </h3>
                 <ul class="space-y-3 text-gray-300">
                     <li class="flex items-start gap-3">
-                        <MapPin class="w-5 h-5 text-primary mt-0.5" />
-                        <span
-                            >Betuwe & Omgeving<br />(Tiel, Culemborg,
-                            Geldermalsen)</span
-                        >
+                        <MapPin class="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                        <span>Randweg 32<br />4116 GH Buren</span>
                     </li>
                     <li class="flex items-center gap-3">
                         <Phone class="w-5 h-5 text-primary" />
@@ -193,11 +190,11 @@ const currentYear = new Date().getFullYear();
                         >
                     </li>
                     <li class="flex items-center gap-3">
-                        <Mail class="w-5 h-5 text-primary" />
+                        <Mail class="w-5 h-5 text-primary flex-shrink-0" />
                         <a
                             href="mailto:info@johnsglazenwassersbedrijf.nl"
                             class="hover:text-white"
-                            >info@johnsglazenwassersbedrijf.nl</a
+                            >Email ons</a
                         >
                     </li>
                     <li class="flex items-center gap-3">

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { Phone, Star, MapPin, Menu, MessageCircle } from "@lucide/astro";
+import { Phone, Star, MapPin, Menu, MessageCircle, X } from "@lucide/astro";
 
 const navItems = [
     { name: "Home", href: "/" },
@@ -35,22 +35,22 @@ const navItems = [
                     <span><strong>4.5/5</strong> op Google</span>
                 </a>
             </div>
-            <div class="flex items-center gap-3">
+            <div class="flex items-center gap-1 sm:gap-3">
                 <a
                     href="tel:0623545276"
-                    class="flex items-center gap-1.5 font-bold hover:text-primary transition-colors"
+                    class="flex items-center gap-1.5 font-bold hover:text-primary transition-colors p-2 -m-2 sm:p-0 sm:m-0"
                 >
-                    <Phone class="w-3.5 h-3.5" />
+                    <Phone class="w-5 h-5 sm:w-3.5 sm:h-3.5" />
                     <span class="hidden sm:inline">06 23545276</span>
                 </a>
                 <a
                     href="https://wa.me/31623545276"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="flex items-center gap-1.5 font-bold hover:text-primary transition-colors"
+                    class="flex items-center gap-1.5 font-bold hover:text-primary transition-colors p-2 -m-2 sm:p-0 sm:m-0"
                     title="WhatsApp"
                 >
-                    <MessageCircle class="w-3.5 h-3.5" />
+                    <MessageCircle class="w-5 h-5 sm:w-3.5 sm:h-3.5" />
                     <span class="hidden sm:inline">WhatsApp</span>
                 </a>
             </div>
@@ -63,7 +63,7 @@ const navItems = [
             <!-- Logo -->
             <a
                 href="/"
-                class="text-xl md:text-2xl font-heading font-extrabold text-navy tracking-tight truncate max-w-[200px] md:max-w-none"
+                class="text-sm sm:text-xl md:text-2xl font-heading font-extrabold text-navy tracking-tight leading-tight"
             >
                 John's Glazenwassersbedrijf<span class="text-primary">.</span>
             </a>
@@ -92,11 +92,74 @@ const navItems = [
                 Bereken je prijs
             </a>
 
-            <!-- Mobile Menu Button (Placeholder) -->
-            <button class="md:hidden text-navy p-2">
+            <!-- Mobile Menu Button -->
+            <button
+                id="mobile-menu-button"
+                class="md:hidden text-navy p-2"
+                aria-expanded="false"
+                aria-controls="mobile-menu"
+            >
                 <span class="sr-only">Menu openen</span>
-                <Menu class="w-8 h-8" />
+                <Menu id="menu-icon-open" class="w-8 h-8" />
+                <X id="menu-icon-close" class="w-8 h-8 hidden" />
             </button>
         </nav>
     </div>
+
+    <!-- Mobile Menu Drawer -->
+    <div
+        id="mobile-menu"
+        class="md:hidden hidden bg-white border-t border-gray-100 shadow-lg"
+    >
+        <nav class="container mx-auto px-4 py-4">
+            <ul class="space-y-1">
+                {
+                    navItems.map((item) => (
+                        <li>
+                            <a
+                                href={item.href}
+                                class="block py-3 px-4 text-navy hover:bg-gray-50 hover:text-primary rounded-lg transition-colors font-medium"
+                            >
+                                {item.name}
+                            </a>
+                        </li>
+                    ))
+                }
+            </ul>
+            <div class="mt-4 pt-4 border-t border-gray-100">
+                <a
+                    href="/offerte"
+                    class="block w-full bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-5 rounded-lg shadow-md transition-all text-center"
+                >
+                    Bereken je prijs
+                </a>
+            </div>
+        </nav>
+    </div>
 </header>
+
+<script>
+    const menuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const iconOpen = document.getElementById('menu-icon-open');
+    const iconClose = document.getElementById('menu-icon-close');
+
+    menuButton?.addEventListener('click', () => {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+
+        menuButton.setAttribute('aria-expanded', (!isExpanded).toString());
+        mobileMenu?.classList.toggle('hidden');
+        iconOpen?.classList.toggle('hidden');
+        iconClose?.classList.toggle('hidden');
+    });
+
+    // Close menu when clicking a link
+    mobileMenu?.querySelectorAll('a').forEach(link => {
+        link.addEventListener('click', () => {
+            mobileMenu.classList.add('hidden');
+            menuButton?.setAttribute('aria-expanded', 'false');
+            iconOpen?.classList.remove('hidden');
+            iconClose?.classList.add('hidden');
+        });
+    });
+</script>

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -7,6 +7,7 @@ import {
     Zap,
     Star,
     User,
+    MapPin,
 } from "@lucide/astro";
 import theCrewImage from "../../assets/images/the-crew-jons-glazenwassersbedrijf.jpg";
 ---
@@ -24,7 +25,7 @@ import theCrewImage from "../../assets/images/the-crew-jons-glazenwassersbedrijf
     </div>
 
     <div
-        class="container mx-auto px-4 pt-32 pb-24 md:pt-48 md:pb-32 relative z-10 grid grid-cols-1 md:grid-cols-2 gap-12 items-center"
+        class="container mx-auto px-4 pt-32 pb-20 md:pt-48 md:pb-28 relative z-10 grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center"
     >
         <!-- Text Content -->
         <div class="space-y-6">
@@ -69,20 +70,24 @@ import theCrewImage from "../../assets/images/the-crew-jons-glazenwassersbedrijf
                 </a>
             </div>
 
-            <div class="pt-4 text-sm text-blue-200 flex items-center gap-4">
+            <div class="pt-4 text-sm text-blue-200 flex flex-wrap items-center gap-x-4 gap-y-2">
                 <span class="flex items-center gap-1">
-                    <CheckCircle2 class="w-4 h-4 text-green-400" />
-                    <span>Binnen 1 minuut geregeld</span>
+                    <ShieldCheck class="w-4 h-4 text-green-400" />
+                    <span>VCA Gecertificeerd</span>
                 </span>
                 <span class="flex items-center gap-1">
-                    <ShieldCheck class="w-4 h-4 text-accent" />
-                    <span>Ruim 1000+ tevreden klanten</span>
+                    <CheckCircle2 class="w-4 h-4 text-accent" />
+                    <span>18 jaar ervaring</span>
+                </span>
+                <span class="hidden md:flex items-center gap-1">
+                    <MapPin class="w-4 h-4 text-blue-400" />
+                    <span>Actief in de hele Betuwe</span>
                 </span>
             </div>
         </div>
 
-        <!-- Hero Image (Right side on Desktop) -->
-        <div class="hidden md:block relative">
+        <!-- Hero Image (Right side on Desktop, Below content on Mobile) -->
+        <div class="relative order-last md:order-none">
             <div class="relative animate-fade-in-up">
                 <!-- Team Image -->
                 <div class="rounded-2xl overflow-hidden shadow-2xl border-4 border-white/20">
@@ -102,34 +107,31 @@ import theCrewImage from "../../assets/images/the-crew-jons-glazenwassersbedrijf
                     href="https://www.google.com/search?q=johns+glazenwassersbedrijf"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="absolute -bottom-4 -left-4 bg-white text-navy p-4 rounded-xl shadow-lg border-l-4 border-accent hover:shadow-xl transition-shadow"
+                    class="absolute -bottom-4 -left-4 bg-white text-navy p-3 md:p-4 rounded-xl shadow-lg border-l-4 border-accent hover:shadow-xl transition-shadow"
                 >
                     <div
-                        class="flex items-center gap-1 font-heading font-bold text-lg"
+                        class="flex items-center gap-1 font-heading font-bold text-sm md:text-lg"
                     >
-                        <Star class="w-5 h-5 text-accent fill-current" />
+                        <Star class="w-4 h-4 md:w-5 md:h-5 text-accent fill-current" />
                         <span>4.5/5 Sterren</span>
                     </div>
-                    <p class="text-sm text-gray-600">op Google Reviews</p>
+                    <p class="text-xs md:text-sm text-gray-600">op Google Reviews</p>
                 </a>
             </div>
         </div>
     </div>
 
     <!-- Wave Separator at bottom -->
-    <div
-        class="absolute bottom-0 left-0 w-full overflow-hidden leading-none z-20"
-    >
+    <div class="absolute bottom-0 left-0 w-full overflow-hidden leading-none z-20">
         <svg
-            class="relative block w-full h-[60px] text-white"
-            data-name="Layer 1"
+            class="relative block w-full h-[40px] md:h-[60px] lg:h-[80px]"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 1200 120"
             preserveAspectRatio="none"
         >
             <path
-                d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
-                class="fill-current"></path>
+                d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V120H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
+                fill="#f9fafb"></path>
         </svg>
     </div>
 </section>

--- a/src/components/home/Reviews.astro
+++ b/src/components/home/Reviews.astro
@@ -1,5 +1,5 @@
 ---
-import { Star, User, Quote, ArrowUpRight } from '@lucide/astro';
+import { Star, User, ArrowUpRight } from '@lucide/astro';
 
 const reviews = [
   {
@@ -37,9 +37,14 @@ const reviews = [
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
             {reviews.map(review => (
                 <div class="bg-gray-50 p-8 rounded-2xl shadow-sm border border-gray-100 relative group hover:shadow-md transition-shadow">
-                    <!-- Google Logo / Icon -->
-                    <div class="absolute top-8 right-8 text-gray-300 group-hover:text-gray-400 transition-colors">
-                         <Quote class="w-8 h-8 opacity-20" />
+                    <!-- Google G Logo -->
+                    <div class="absolute top-6 right-6 opacity-40 group-hover:opacity-60 transition-opacity">
+                        <svg class="w-6 h-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                        </svg>
                     </div>
                     
                     <div class="flex text-accent mb-4">

--- a/src/components/home/TrustBar.astro
+++ b/src/components/home/TrustBar.astro
@@ -1,36 +1,31 @@
 ---
-import { Star, ShieldCheck, MapPin, CheckCircle2 } from "@lucide/astro";
+import { ShieldCheck, MapPin, CheckCircle2 } from "@lucide/astro";
 ---
 
-<section class="bg-navy border-b border-white/5 py-4">
+<section class="hidden bg-navy border-b border-white/5 py-3">
     <div class="container mx-auto px-4">
         <div
-            class="flex flex-wrap justify-center sm:justify-between items-center gap-6 text-gray-300 text-sm font-medium"
+            class="flex justify-center items-center gap-4 sm:gap-8 text-gray-300 text-xs sm:text-sm font-medium"
         >
-            <a href="https://www.google.com/search?q=johns+glazenwassersbedrijf" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 hover:text-white transition-colors">
-                <Star class="w-5 h-5 text-accent fill-current" />
-                <span>4.5/5 gemiddelde beoordeling</span>
-            </a>
-
-            <div class="hidden sm:block w-1 h-1 bg-gray-600 rounded-full"></div>
-
-            <div class="flex items-center gap-2">
-                <ShieldCheck class="w-5 h-5 text-green-400" />
+            <div class="flex items-center gap-1.5 sm:gap-2">
+                <ShieldCheck class="w-4 h-4 sm:w-5 sm:h-5 text-green-400 flex-shrink-0" />
                 <span>VCA Gecertificeerd</span>
             </div>
 
-            <div class="hidden sm:block w-1 h-1 bg-gray-600 rounded-full"></div>
+            <div class="w-1 h-1 bg-gray-600 rounded-full flex-shrink-0"></div>
 
-            <div class="flex items-center gap-2">
-                <MapPin class="w-5 h-5 text-blue-400" />
-                <span>Actief in de hele Betuwe</span>
+            <div class="flex items-center gap-1.5 sm:gap-2">
+                <MapPin class="w-4 h-4 sm:w-5 sm:h-5 text-blue-400 flex-shrink-0" />
+                <span class="hidden sm:inline">Actief in de hele Betuwe</span>
+                <span class="sm:hidden">Hele Betuwe</span>
             </div>
 
-            <div class="hidden sm:block w-1 h-1 bg-gray-600 rounded-full"></div>
+            <div class="w-1 h-1 bg-gray-600 rounded-full flex-shrink-0"></div>
 
-            <div class="flex items-center gap-2">
-                <CheckCircle2 class="w-5 h-5 text-accent" />
-                <span>100% tevredenheidsgarantie</span>
+            <div class="flex items-center gap-1.5 sm:gap-2">
+                <CheckCircle2 class="w-4 h-4 sm:w-5 sm:h-5 text-accent flex-shrink-0" />
+                <span class="hidden sm:inline">100% tevredenheidsgarantie</span>
+                <span class="sm:hidden">100% garantie</span>
             </div>
         </div>
     </div>

--- a/src/pages/diensten/index.astro
+++ b/src/pages/diensten/index.astro
@@ -26,7 +26,7 @@ import ServiceCards from "../../components/home/ServiceCards.astro";
             <div class="container mx-auto px-4 max-w-4xl">
                 <div class="text-center mb-12">
                     <h2 class="font-heading font-bold text-3xl text-navy mb-4">
-                        Waarom kiezen voor John's?
+                        Waarom kiezen voor John's Glazenwassersbedrijf?
                     </h2>
                     <p class="text-lg text-gray-600">
                         Sinds 2007 zorgen wij voor tevreden klanten in de Betuwe

--- a/src/pages/over-ons.astro
+++ b/src/pages/over-ons.astro
@@ -63,7 +63,7 @@ import theCrewImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jp
                                 />
                             </div>
                             <h3 class="font-heading font-bold text-xl text-navy">John Hak</h3>
-                            <p class="text-gray-600">Eigenaar</p>
+                            <p class="text-gray-600">Blink Baas</p>
                         </div>
 
                         <!-- Egbert van Zijl -->
@@ -71,7 +71,7 @@ import theCrewImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jp
                             <div class="mb-4 rounded-2xl overflow-hidden shadow-lg">
                                 <Image
                                     src={egbertImage}
-                                    alt="Egbert van Zijl, glazenwasser bij John's Glazenwassersbedrijf"
+                                    alt="Egbert van Zijl, Streeploos Specialist bij John's Glazenwassersbedrijf"
                                     width={293}
                                     height={440}
                                     loading="lazy"
@@ -80,7 +80,7 @@ import theCrewImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jp
                                 />
                             </div>
                             <h3 class="font-heading font-bold text-xl text-navy">Egbert van Zijl</h3>
-                            <p class="text-gray-600">Glazenwasser</p>
+                            <p class="text-gray-600">Streeploos Specialist</p>
                         </div>
 
                         <!-- Benny Mulder -->
@@ -88,7 +88,7 @@ import theCrewImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jp
                             <div class="mb-4 rounded-2xl overflow-hidden shadow-lg">
                                 <Image
                                     src={bennyImage}
-                                    alt="Benny Mulder, glazenwasser bij John's Glazenwassersbedrijf"
+                                    alt="Benny Mulder, Glans Goeroe bij John's Glazenwassersbedrijf"
                                     width={293}
                                     height={440}
                                     loading="lazy"
@@ -97,7 +97,7 @@ import theCrewImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jp
                                 />
                             </div>
                             <h3 class="font-heading font-bold text-xl text-navy">Benny Mulder</h3>
-                            <p class="text-gray-600">Glazenwasser</p>
+                            <p class="text-gray-600">Glans Goeroe</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Fix logo truncation on mobile with responsive text sizing
- Add functional hamburger menu with slide-out navigation
- Show crew image on mobile below CTAs
- Improve wave transition between hero and content sections
- Make contact buttons larger and more tappable on mobile
- Replace quote icon with Google G logo on review cards
- Update trust badges layout (integrated into hero on mobile)
- Add proper address and cleaner email link in footer
- Update team titles to fun alliterative names
- Use full company name consistently throughout

## Test plan
- [ ] Test mobile header: logo visible, hamburger menu works
- [ ] Test hero section: crew image shows, wave transition smooth
- [ ] Test contact buttons in top bar are easily tappable
- [ ] Verify review cards show Google G logo
- [ ] Check footer displays correct address and "Email ons" link
- [ ] Verify over-ons page shows new team titles

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)