### PR TITLE
perf: make Google Fonts non-render-blocking

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,10 +19,12 @@ const { title, description = "De glazenwasser uit de Betuwe met een persoonlijke
 		<link rel="apple-touch-icon" href="/favicon.png" />
 		<meta name="generator" content={Astro.generator} />
         
-        <!-- Google Fonts: Outfit (Headings) & Inter (Body) -->
+        <!-- Google Fonts: Non-blocking load with system font fallback -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;700;800&display=swap" rel="stylesheet">
+        <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;700;800&display=swap" as="style">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;700;800&display=swap" media="print" onload="this.media='all'">
+        <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;700;800&display=swap"></noscript>
         
 		<title>{title} | John's Glazenwassersbedrijf</title>
 	</head>


### PR DESCRIPTION
## Summary

Eliminates ~750ms render-blocking delay from Google Fonts CSS.

## Changes

- Added `rel="preload"` hint for early font CSS fetch
- Changed stylesheet to load with `media="print" onload="this.media='all'"` pattern
- Added `<noscript>` fallback for non-JS browsers

## How it works

1. Browser sees `media="print"` → doesn't block rendering
2. Preload hint fetches the CSS in parallel
3. Once loaded, `onload` changes media to `all` → styles apply
4. System font fallbacks (added in #16) ensure text is visible immediately

## Expected improvement

- Est. ~750ms reduction in render-blocking time
- Combined with system font fallbacks, text appears instantly

🤖 Generated with [Claude Code](https://claude.ai/code)