### PR TITLE
perf: prerender homepage and preload hero image

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,9 +4,10 @@ import '../styles/global.css';
 interface Props {
 	title: string;
 	description?: string;
+	preloadImage?: string;
 }
 
-const { title, description = "De glazenwasser uit de Betuwe met een persoonlijke benadering!" } = Astro.props;
+const { title, description = "De glazenwasser uit de Betuwe met een persoonlijke benadering!", preloadImage } = Astro.props;
 ---
 
 <!doctype html>
@@ -27,6 +28,7 @@ const { title, description = "De glazenwasser uit de Betuwe met een persoonlijke
         <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;700;800&display=swap"></noscript>
         
 		<title>{title} | John's Glazenwassersbedrijf</title>
+		{preloadImage && <link rel="preload" as="image" href={preloadImage} fetchpriority="high" />}
 	</head>
 	<body class="font-body text-navy antialiased bg-white flex flex-col min-h-screen">
 		<slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getImage } from "astro:assets";
 import Layout from "../layouts/Layout.astro";
 import Header from "../components/common/Header.astro";
 import Footer from "../components/common/Footer.astro";
@@ -6,9 +7,16 @@ import Hero from "../components/home/Hero.astro";
 import TrustBar from "../components/home/TrustBar.astro";
 import ServiceCards from "../components/home/ServiceCards.astro";
 import Reviews from "../components/home/Reviews.astro";
+import heroImage from "../assets/images/the-crew-jons-glazenwassersbedrijf.jpg";
+
+// Prerender for instant TTFB (static HTML)
+export const prerender = true;
+
+// Get optimized hero image URL for preloading
+const optimizedHero = await getImage({ src: heroImage, width: 800, height: 534, format: 'webp' });
 ---
 
-<Layout title="Home">
+<Layout title="Home" preloadImage={optimizedHero.src}>
 	<Header />
 	<main>
 		<Hero />


### PR DESCRIPTION
## Summary

Two major performance optimizations for FCP/LCP:

### 1. Prerender Homepage
- Added `export const prerender = true` to index.astro
- Homepage is now static HTML generated at build time
- Eliminates server-side rendering latency (TTFB → near instant)

### 2. Preload Hero Image
- Hero image now has `<link rel="preload">` in the `<head>`
- Browser starts downloading the LCP image immediately
- No longer waits for HTML/CSS parsing to discover the image

## Technical Details
- Used `getImage()` from `astro:assets` to get the optimized WebP URL
- Added reusable `preloadImage` prop to Layout component
- Hero image preloaded: `/_astro/the-crew-jons-glazenwassersbedrijf.15SDKZ8I_2lSLCz.webp` (39KB)

## Expected Improvement
- FCP: 2.7s → ~1.2-1.5s (est. 50% reduction)
- LCP: 2.7s → ~1.5-1.8s (est. 40% reduction)

🤖 Generated with [Claude Code](https://claude.ai/code)