### PR TITLE
fix: enforce consistent trailing slashes and add sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,13 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@tailwindcss/vite';
 import cloudflare from '@astrojs/cloudflare';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-    trailingSlash: 'never',
+    site: 'https://johnsglazenwassersbedrijf.nl',
+    trailingSlash: 'always',
+    integrations: [sitemap()],
     adapter: cloudflare(),
     vite: {
         plugins: [tailwind()],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.12",
+        "@astrojs/sitemap": "^3.7.0",
         "@lucide/astro": "^0.563.0",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.16.16",
@@ -85,6 +86,17 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.0.tgz",
+      "integrity": "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.2",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.25.76"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2033,6 +2045,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
+      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2164,6 +2194,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5651,6 +5687,31 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.2.tgz",
+      "integrity": "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -5691,6 +5752,12 @@
         "node": ">=4",
         "npm": ">=6"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5923,6 +5990,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.12",
+    "@astrojs/sitemap": "^3.7.0",
+    "@lucide/astro": "^0.563.0",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.16.16",
     "framer-motion": "^12.29.2",
-    "@lucide/astro": "^0.563.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.18"
   }

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -35,28 +35,28 @@ const currentYear = new Date().getFullYear();
                 <ul class="space-y-3">
                     <li>
                         <a
-                            href="/diensten"
+                            href="/diensten/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Diensten</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/over-ons"
+                            href="/over-ons/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Over Ons</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/contact"
+                            href="/contact/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Contact</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/offerte"
+                            href="/offerte/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Offerte Aanvragen</a
                         >
@@ -72,56 +72,56 @@ const currentYear = new Date().getFullYear();
                 <ul class="space-y-3">
                     <li>
                         <a
-                            href="/diensten/glasbewassing"
+                            href="/diensten/glasbewassing/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glasbewassing</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/zonnepanelen"
+                            href="/diensten/zonnepanelen/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Zonnepanelen Reinigen</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/dakgoten"
+                            href="/diensten/dakgoten/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Dakgoten Leegmaken</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/houtwerk"
+                            href="/diensten/houtwerk/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Houtwerk & Trespa</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/bouwoplevering"
+                            href="/diensten/bouwoplevering/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Bouwoplevering</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/kantoor"
+                            href="/diensten/kantoor/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Kantoor Reiniging</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/dakpannen"
+                            href="/diensten/dakpannen/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Dakpannen Reinigen</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/diensten/telewash"
+                            href="/diensten/telewash/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Telewash Systeem</a
                         >
@@ -137,35 +137,35 @@ const currentYear = new Date().getFullYear();
                 <ul class="space-y-3">
                     <li>
                         <a
-                            href="/glazenwasser-tiel"
+                            href="/glazenwasser-tiel/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glazenwasser Tiel</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/glazenwasser-geldermalsen"
+                            href="/glazenwasser-geldermalsen/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glazenwasser Geldermalsen</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/glazenwasser-culemborg"
+                            href="/glazenwasser-culemborg/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glazenwasser Culemborg</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/glazenwasser-meteren"
+                            href="/glazenwasser-meteren/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glazenwasser Meteren</a
                         >
                     </li>
                     <li>
                         <a
-                            href="/glazenwasser-buren"
+                            href="/glazenwasser-buren/"
                             class="text-gray-300 hover:text-white transition-colors"
                             >Glazenwasser Buren</a
                         >

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -3,10 +3,10 @@ import { Phone, Star, MapPin, Menu, MessageCircle, X } from "@lucide/astro";
 
 const navItems = [
     { name: "Home", href: "/" },
-    { name: "Diensten", href: "/diensten" },
-    { name: "Over Ons", href: "/over-ons" },
+    { name: "Diensten", href: "/diensten/" },
+    { name: "Over Ons", href: "/over-ons/" },
     { name: "Reviews", href: "/#reviews" },
-    { name: "Contact", href: "/contact" },
+    { name: "Contact", href: "/contact/" },
 ];
 ---
 
@@ -87,7 +87,7 @@ const navItems = [
 
             <!-- CTA Button -->
             <a
-                href="/offerte"
+                href="/offerte/"
                 class="hidden md:inline-block bg-accent hover:bg-accent-dark text-navy font-bold py-2 px-5 rounded-lg shadow-md transition-all hover:-translate-y-0.5"
             >
                 Bereken je prijs
@@ -129,7 +129,7 @@ const navItems = [
             </ul>
             <div class="mt-4 pt-4 border-t border-gray-100">
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="block w-full bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-5 rounded-lg shadow-md transition-all text-center"
                 >
                     Bereken je prijs

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -55,7 +55,7 @@ import theCrewImage from "../../assets/images/the-crew-jons-glazenwassersbedrijf
 
             <div class="flex flex-col sm:flex-row gap-4 pt-4">
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-8 rounded-xl shadow-xl transition-all hover:scale-105 hover:shadow-2xl flex items-center justify-center gap-2"
                 >
                     <Zap class="w-5 h-5" />

--- a/src/components/home/ServiceCards.astro
+++ b/src/components/home/ServiceCards.astro
@@ -19,7 +19,7 @@ const services = [
         icon: Droplets,
         image: ramenWassenImage,
         alt: "Professionele glazenwasser reinigt ramen met osmose-water in de Betuwe",
-        link: "/diensten/glasbewassing",
+        link: "/diensten/glasbewassing/",
     },
     {
         title: "Zonnepanelen",
@@ -28,7 +28,7 @@ const services = [
         icon: Sun,
         image: zonnepanelenImage,
         alt: "Vakkundig reinigen van zonnepanelen voor optimaal rendement",
-        link: "/diensten/zonnepanelen",
+        link: "/diensten/zonnepanelen/",
     },
     {
         title: "Dakgoten",
@@ -37,7 +37,7 @@ const services = [
         icon: CloudRain,
         image: dakgotenImage,
         alt: "Dakgoten legen en schoonmaken voorkomt waterschade",
-        link: "/diensten/dakgoten",
+        link: "/diensten/dakgoten/",
     },
     {
         title: "Houtwerk & Trespa",
@@ -46,7 +46,7 @@ const services = [
         icon: Home,
         image: houtwerkImage,
         alt: "Reinigen van houtwerk, kunststof kozijnen en trespa gevelbekleding",
-        link: "/diensten/houtwerk",
+        link: "/diensten/houtwerk/",
     },
     {
         title: "Bouwoplevering",
@@ -55,7 +55,7 @@ const services = [
         icon: Building2,
         image: bouwopleveringImage,
         alt: "Professionele bouwoplevering reiniging voor nieuwbouw en verbouwingen",
-        link: "/diensten/bouwoplevering",
+        link: "/diensten/bouwoplevering/",
     },
     {
         title: "Kantoor Reiniging",
@@ -64,7 +64,7 @@ const services = [
         icon: Briefcase,
         image: kantoorImage,
         alt: "Team glazenwassers reinigt kantoorpand en bedrijfsruimte",
-        link: "/diensten/kantoor",
+        link: "/diensten/kantoor/",
     },
     {
         title: "Dakpannen",
@@ -73,7 +73,7 @@ const services = [
         icon: Layers,
         image: dakpannenImage,
         alt: "Dakpannen reinigen en ontmossen voor langere levensduur",
-        link: "/diensten/dakpannen",
+        link: "/diensten/dakpannen/",
     },
     {
         title: "Telewash Systeem",
@@ -82,7 +82,7 @@ const services = [
         icon: Zap,
         image: telewashImage,
         alt: "Telewash systeem voor hoogwerkreiniging van moeilijk bereikbare plekken",
-        link: "/diensten/telewash",
+        link: "/diensten/telewash/",
     },
 ];
 ---

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -161,7 +161,7 @@ import { Phone, Mail, MapPin } from "@lucide/astro";
                                     Je hoeft niet te wachten. Gebruik onze configurator om direct een indicatie te krijgen.
                                 </p>
                                 <a
-                                    href="/offerte"
+                                    href="/offerte/"
                                     class="bg-white text-primary font-bold py-3 px-6 rounded-lg inline-block hover:bg-gray-100 transition-colors"
                                 >
                                     Ga naar de configurator

--- a/src/pages/diensten/bouwoplevering.astro
+++ b/src/pages/diensten/bouwoplevering.astro
@@ -23,7 +23,7 @@ import bouwopleveringImage from "../../assets/images/bouw-opleveringen.jpg";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/dakgoten.astro
+++ b/src/pages/diensten/dakgoten.astro
@@ -23,7 +23,7 @@ import dakgotenImage from "../../assets/images/dakgoten-leegmaken.jpg";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Direct inplannen

--- a/src/pages/diensten/dakpannen.astro
+++ b/src/pages/diensten/dakpannen.astro
@@ -23,7 +23,7 @@ import dakpannenImage from "../../assets/images/dakpannen-reinigen.jpg";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/glasbewassing.astro
+++ b/src/pages/diensten/glasbewassing.astro
@@ -23,7 +23,7 @@ import ramenWassenImage from "../../assets/images/ramen-wassen.jpg";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/houtwerk.astro
+++ b/src/pages/diensten/houtwerk.astro
@@ -23,7 +23,7 @@ import houtwerkImage from "../../assets/images/reinigen-van-houtwerk-kunststof-e
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Prijs opvragen

--- a/src/pages/diensten/index.astro
+++ b/src/pages/diensten/index.astro
@@ -112,13 +112,13 @@ import ServiceCards from "../../components/home/ServiceCards.astro";
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
                     <a
-                        href="/contact"
+                        href="/contact/"
                         class="bg-primary hover:bg-primary/90 text-white font-bold py-3 px-8 rounded-lg transition-colors inline-block"
                     >
                         Neem contact op
                     </a>
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg transition-colors inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/kantoor.astro
+++ b/src/pages/diensten/kantoor.astro
@@ -21,7 +21,7 @@ import Footer from "../../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/telewash.astro
+++ b/src/pages/diensten/telewash.astro
@@ -23,7 +23,7 @@ import telewashImage from "../../assets/images/reinigen-met-telewash-systeem.jpg
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Bereken je prijs

--- a/src/pages/diensten/zonnepanelen.astro
+++ b/src/pages/diensten/zonnepanelen.astro
@@ -23,7 +23,7 @@ import zonnepanelenImage from "../../assets/images/reinigen-van-zonnepanelen.jpg
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Offerte aanvragen

--- a/src/pages/glazenwasser-buren.astro
+++ b/src/pages/glazenwasser-buren.astro
@@ -20,7 +20,7 @@ import Footer from "../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Vraag een offerte aan
@@ -92,7 +92,7 @@ import Footer from "../components/common/Footer.astro";
                     Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
                 </p>
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
                 >
                     Bereken je prijs

--- a/src/pages/glazenwasser-culemborg.astro
+++ b/src/pages/glazenwasser-culemborg.astro
@@ -20,7 +20,7 @@ import Footer from "../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Vraag een offerte aan
@@ -92,7 +92,7 @@ import Footer from "../components/common/Footer.astro";
                     Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
                 </p>
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
                 >
                     Bereken je prijs

--- a/src/pages/glazenwasser-geldermalsen.astro
+++ b/src/pages/glazenwasser-geldermalsen.astro
@@ -20,7 +20,7 @@ import Footer from "../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Vraag een offerte aan
@@ -86,7 +86,7 @@ import Footer from "../components/common/Footer.astro";
                     Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
                 </p>
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
                 >
                     Bereken je prijs

--- a/src/pages/glazenwasser-meteren.astro
+++ b/src/pages/glazenwasser-meteren.astro
@@ -20,7 +20,7 @@ import Footer from "../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Vraag een offerte aan
@@ -86,7 +86,7 @@ import Footer from "../components/common/Footer.astro";
                     Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
                 </p>
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
                 >
                     Bereken je prijs

--- a/src/pages/glazenwasser-tiel.astro
+++ b/src/pages/glazenwasser-tiel.astro
@@ -20,7 +20,7 @@ import Footer from "../components/common/Footer.astro";
                 </p>
                 <div class="mt-8">
                     <a
-                        href="/offerte"
+                        href="/offerte/"
                         class="bg-accent hover:bg-accent-dark text-navy font-bold py-3 px-8 rounded-lg shadow-lg transition-transform hover:scale-105 inline-block"
                     >
                         Vraag een offerte aan
@@ -96,7 +96,7 @@ import Footer from "../components/common/Footer.astro";
                     Bereken binnen 1 minuut je prijs en ontvang direct een vrijblijvend voorstel.
                 </p>
                 <a
-                    href="/offerte"
+                    href="/offerte/"
                     class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
                 >
                     Bereken je prijs

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ const optimizedHero = await getImage({ src: heroImage, width: 800, height: 534, 
 					vrijblijvend voorstel.
 				</p>
 				<a
-					href="/offerte"
+					href="/offerte/"
 					class="bg-accent hover:bg-accent-dark text-navy font-bold text-lg py-4 px-10 rounded-full shadow-lg transition-transform hover:scale-105 inline-block"
 				>
 					Bereken je prijs


### PR DESCRIPTION
## Summary
- Set `trailingSlash: 'always'` to match Cloudflare Pages behavior
- Update all internal links to use trailing slashes (19 files)
- Add `@astrojs/sitemap` integration for SEO

## Why
Cloudflare Pages enforces trailing slashes for directory-style URLs. Having inconsistent links caused redirect loops (`/diensten` → `/diensten/` → `/diensten`), hurting SEO and performance.

## Test plan
- [x] Build completes successfully
- [x] Sitemap generated at `sitemap-index.xml`
- [x] All internal links use trailing slashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)