### PR TITLE
fix: add noindex meta tag to prevent search engine indexing

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,7 @@ const { title, description = "De glazenwasser uit de Betuwe met een persoonlijke
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<link rel="apple-touch-icon" href="/favicon.png" />
+		<meta name="robots" content="noindex, nofollow" />
 		<meta name="generator" content={Astro.generator} />
         
         <!-- Google Fonts: Non-blocking load with system font fallback -->


### PR DESCRIPTION
## Summary
- Add `<meta name="robots" content="noindex, nofollow" />` to the base layout `<head>` to prevent search engines from indexing this demo site
- Combined with the existing `robots.txt` (`Disallow: /`), fully prevents indexing

## Test plan
- [ ] Verify the meta tag appears in the `<head>` of every page
- [ ] Confirm `robots.txt` still serves `Disallow: /`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)